### PR TITLE
Fix variable scoping bug and optimize session loading

### DIFF
--- a/clinic-medical/src/pages/AssignAppointmentPage.jsx
+++ b/clinic-medical/src/pages/AssignAppointmentPage.jsx
@@ -6,7 +6,7 @@ function AssignAppointmentPage() {
   const navigate = useNavigate();
   const { requestId } = useParams();
   const API_BASE_URL = useMemo(() => resolveApiBaseUrl(), []);
-  const session = getReceptionPortalSession();
+  const session = useMemo(() => getReceptionPortalSession(), []);
 
   const [request, setRequest] = useState(null);
   const [loadError, setLoadError] = useState('');

--- a/clinic-medical/src/pages/CreateAppointmentPage.jsx
+++ b/clinic-medical/src/pages/CreateAppointmentPage.jsx
@@ -6,7 +6,7 @@ function CreateAppointmentPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const API_BASE_URL = useMemo(() => resolveApiBaseUrl(), []);
-  const session = getReceptionPortalSession();
+  const session = useMemo(() => getReceptionPortalSession(), []);
 
   const [doctors, setDoctors] = useState([]);
   const [locations, setLocations] = useState([]);

--- a/clinic-medical/src/pages/DentistProfilePage.jsx
+++ b/clinic-medical/src/pages/DentistProfilePage.jsx
@@ -52,7 +52,7 @@ const formatDateTimeWithMeridiem = (value) => {
 function DentistProfilePage() {
   const API_BASE_URL = useMemo(() => resolveApiBaseUrl(), []);
   const navigate = useNavigate();
-  const session = getDentistPortalSession();
+  const session = useMemo(() => getDentistPortalSession(), []);
   const fileInputRef = useRef(null);
 
   const formatEmergencyPhone = (value) => {

--- a/clinic-medical/src/pages/PatientDashboardPage.jsx
+++ b/clinic-medical/src/pages/PatientDashboardPage.jsx
@@ -7,7 +7,7 @@ import autoTable from 'jspdf-autotable';
 function PatientDashboardPage() {
   const { patientId } = useParams();
   const API_BASE_URL = useMemo(() => resolveApiBaseUrl(), []);
-  const session = getReceptionPortalSession();
+  const session = useMemo(() => getReceptionPortalSession(), []);
 
   const [patientDetail, setPatientDetail] = useState(null);
   const [message, setMessage] = useState('');

--- a/clinic-medical/src/pages/ReceptionistPage.jsx
+++ b/clinic-medical/src/pages/ReceptionistPage.jsx
@@ -84,7 +84,7 @@ function PatientSearch() {
 function ReceptionistPage() {
   const navigate = useNavigate();
   const API_BASE_URL = useMemo(() => resolveApiBaseUrl(), []);
-  const session = getReceptionPortalSession();
+  const session = useMemo(() => getReceptionPortalSession(), []);
 
   const fetchWithTimeout = async (url, options = {}, timeoutMs = 10000) => {
     const controller = new AbortController();

--- a/clinic-medical/src/pages/ReceptionistProfilePage.jsx
+++ b/clinic-medical/src/pages/ReceptionistProfilePage.jsx
@@ -52,7 +52,7 @@ const formatDateTimeWithMeridiem = (value) => {
 function ReceptionistProfilePage() {
   const API_BASE_URL = useMemo(() => resolveApiBaseUrl(), []);
   const navigate = useNavigate();
-  const session = getReceptionPortalSession();
+  const session = useMemo(() => getReceptionPortalSession(), []);
   const fileInputRef = useRef(null);
 
   const formatEmergencyPhone = (value) => {

--- a/clinic-medical/src/pages/RegisterPatientPage.jsx
+++ b/clinic-medical/src/pages/RegisterPatientPage.jsx
@@ -97,7 +97,7 @@ const TIME_PREFERENCE_OPTIONS = [
 function RegisterPatientPage() {
   const navigate = useNavigate();
   const API_BASE_URL = useMemo(() => resolveApiBaseUrl(), []);
-  const session = getReceptionPortalSession();
+  const session = useMemo(() => getReceptionPortalSession(), []);
 
   const [step, setStep] = useState(1);
   const [submittingRegistration, setSubmittingRegistration] = useState(false);

--- a/routes/receptionRoutes.js
+++ b/routes/receptionRoutes.js
@@ -346,9 +346,9 @@ function createReceptionRoutes({ pool, sendJSON }) {
         [doctorId, locationId, appointmentDate, appointmentTime, appointmentEndTime, createdBy, createdBy]
       );
       slotId = Number(slotInsert.insertId);
-      currentBookings = 0;
-      maxPatients = 1;
-      isAvailable = true;
+      let currentBookings = 0;
+      let maxPatients = 1;
+      let isAvailable = true;
     }
 
     const [appointmentInsert] = await conn.promise().query(


### PR DESCRIPTION
 Add let to 3 implicit global variables in receptionRoutes.js. Wrap session calls in useMemo across 7 pages to prevent redundant localStorage reads on every re-render.