### PR TITLE
Fix: cancel appointment route

### DIFF
--- a/clinic-medical/src/pages/PatientPortalPage.jsx
+++ b/clinic-medical/src/pages/PatientPortalPage.jsx
@@ -452,7 +452,7 @@ function PatientPortalPage() {
                         type="button"
                         className="portal-link-btn"
                         style={{ color: '#a53030', borderColor: '#e8b4b4' }}
-                        onClick={() => setCancelState({ open: true, reasonId: '', submitting: false })}
+                        onClick={() => setCancelState({ open: true, cancelNote: '', submitting: false })}
                         >
                         Cancel Appointment
                         </button>


### PR DESCRIPTION
before when cancel appointment was pressed on the patient portal, the website crashed becuase it was not routed /navigated correctly, now instead of routing to a reasonID, it routes to a cancelNote, basically instead of the dropdown, it goes to a cancel note
reasonID was a previous version of the code where there was a dropdown, cancelNote is a new version that allows n open message